### PR TITLE
Fix crash when bot names are too long

### DIFF
--- a/lib/views/arena.rb
+++ b/lib/views/arena.rb
@@ -21,7 +21,6 @@ module Views
 
       available_colors = [@pastel.red.detach, @pastel.green.detach, @pastel.blue.detach, @pastel.yellow.detach, @pastel.white.detach]
       @bot_colors = bots.to_h {|bot| [bot.display_name, available_colors.shift()]}
-      names = bots.map {|bot| bot.display_name()}
 
       print TTY::Box.frame(
         width: width + 2,
@@ -33,8 +32,7 @@ module Views
           }
         },
         title: {
-          top_center: 'BOT BATTLE ARENA',
-          bottom_center: names.join(" vs. ")
+          top_center: 'BOT BATTLE ARENA'
         }
       )
 


### PR DESCRIPTION
When the total length of the combatants' names exceeds the available
space on the bottom of the arena frame, the program crashes.

For the time being, just omit the bot names from the frame entirely
since they are also shown in the stat box on the right.