### PR TITLE
Fix zombie bot bug

### DIFF
--- a/lib/models/arena.rb
+++ b/lib/models/arena.rb
@@ -54,6 +54,9 @@ module Models
         end
       end
 
+      @bots.reject! {|bot| @bot_states[bot].health <= 0 }
+      @bot_states.reject! {|bot, state| state.health <= 0 }
+
       return Models::TurnResult.new(action_results, safe_bot_states())
     end
 


### PR DESCRIPTION
When a bot was defeated in the arena (health <= 0), it was not actually
removed from the arena. This fix checks all bots' health after each turn
and removes dead bots from the arena.