### PR TITLE
Fix simultaneous repair/death animation

### DIFF
--- a/lib/models/arena.rb
+++ b/lib/models/arena.rb
@@ -46,10 +46,7 @@ module Models
 
       @bots.each do |bot|
         begin
-          action_result = Actions::Factory.create_executor(unsafe_game_state, actions[bot]).call(@bot_states[bot])
-
-          get_dead_bots().each {|dead_bot| action_result.animations.push(Actions::Animations::DestroyBot.new(@bot_states[dead_bot].position)) }
-          action_results << action_result
+          action_results.push(Actions::Factory.create_executor(unsafe_game_state, actions[bot]).call(@bot_states[bot]))
         rescue Exceptions::InsufficientEnergyError => e
           # TODO: Add an animation to indicate the energy shortage
           # Suppress error for now
@@ -60,6 +57,7 @@ module Models
         end
       end
 
+      get_dead_bots().each {|dead_bot| action_results[0].animations.push(Actions::Animations::DestroyBot.new(@bot_states[dead_bot].position)) }
       @bots.reject! {|bot| bot_dead?(@bot_states[bot]) }
       @bot_states.reject! {|bot, state| bot_dead?(state) }
 


### PR DESCRIPTION
When a bot is "killed" on the same turn that it is repairing (meaning it does not die, because the repair saves it) both the death and repair animations were being shown. This change moves the check for dead bots outside of the bot action executor loop so we only show a death animation if a bot actually dies.

Note that this is still not the best way to fix this problem, as we're just putting all death animations onto the first (possibly-unrelated) action result. However, this works for now until we have time to refactor more in the future.