### PR TITLE
Make AnimationManager.render public

### DIFF
--- a/lib/views/animations/animation_manager.rb
+++ b/lib/views/animations/animation_manager.rb
@@ -37,15 +37,15 @@ module Views
         return @animations.empty?()
       end
 
+      def render(frame, render_offset)
+        @animations.each { |animation| animation.render(frame, render_offset) }
+        remove_completed_animations()
+      end
+
       private
 
       def remove_completed_animations()
         @animations.reject! { |animation| animation.complete?() }
-      end
-
-      def render(frame, render_offset)
-        @animations.each { |animation| animation.render(frame, render_offset) }
-        remove_completed_animations()
       end
 
       def animations_complete?()


### PR DESCRIPTION
The render method was erroneously marked as private, but it needs to be called from game.rb. This change makes it public again.